### PR TITLE
Lat lng api

### DIFF
--- a/app/services/google_geocode_service.rb
+++ b/app/services/google_geocode_service.rb
@@ -1,0 +1,32 @@
+class GoogleGeocodeService
+  def initialize(zip)
+    @zip = zip
+  end
+
+  def lat
+    location_data[:results][0][:geometry][:location][:lat]
+  end
+
+  def lng
+    location_data[:results][0][:geometry][:location][:lng]
+  end
+
+  def location_data
+    get_json("/maps/api/geocode/json?address=#{@zip}") 
+  end
+
+  private
+
+  def get_json(url)
+    response = conn.get(url)
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: 'https://maps.googleapis.com') do |faraday|
+      faraday.params['key'] = ENV['google_api']
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/spec/services/google_geocode_spec.rb
+++ b/spec/services/google_geocode_spec.rb
@@ -2,9 +2,16 @@ require 'rails_helper'
 
 describe 'with a zip code' do
   it 'can send back lat long' do
-    zip = 80003
+    zip = 80204
     geo_service = GoogleGeocodeService.new(zip)
-    expect(geo_service.lat).to eq(39.8182494)
-    expect(geo_service.lng).to eq(-105.0674317)
+    expect(geo_service.lat).to eq(39.7380371)
+    expect(geo_service.lng).to eq(-105.0265195)
+  end
+
+  it 'can send back a different lat long' do
+    zip = 84103
+    geo_service = GoogleGeocodeService.new(zip)
+    expect(geo_service.lat).to eq(40.810506)
+    expect(geo_service.lng).to eq(-111.8449346)
   end
 end

--- a/spec/services/google_geocode_spec.rb
+++ b/spec/services/google_geocode_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'with a zip code' do
+  it 'can send back lat long' do
+    zip = 80003
+    geo_service = GoogleGeocodeService.new(zip)
+    expect(geo_service.lat).to eq(39.8182494)
+    expect(geo_service.lng).to eq(-105.0674317)
+  end
+end


### PR DESCRIPTION
Adds google api geocoding service to find latitude and longitude from entering a zip code. Start service with geo_service = GoogleGeocodeService.new(zip) and call lat and long with geo_service.lat and geo_service.lng